### PR TITLE
fix: popraw wyznaczanie winnerTeam (30% gier miało błędną drużynę)

### DIFF
--- a/scripts/backfill-winner-team.ts
+++ b/scripts/backfill-winner-team.ts
@@ -1,0 +1,154 @@
+/**
+ * Jednorazowa korekta `games.winnerTeam` / `games.winCondition` dla gier
+ * zaimportowanych zanim `createGame.ts` zaczął używać `determineTeam()`.
+ *
+ * Stara logika wyznaczała drużynę z dwóch zaszytych list obejmujących 12 z 55
+ * ról, klasyfikowała `glitch` jako impostora i czytała rolę POCZĄTKOWĄ — przez
+ * co wygrane m.in. Warlocka, Werewolfa i Vampira zapisywały się jako
+ * "Crewmate". Nowe gry są już poprawne; ten skrypt naprawia historię.
+ *
+ * Uruchamiany ręcznie, osobno dla każdego środowiska. Domyślnie tylko generuje
+ * SQL do przejrzenia — bez `--apply` nic nie trafia do bazy:
+ *   npx tsx scripts/backfill-winner-team.ts --local
+ *   npx tsx scripts/backfill-winner-team.ts --preview
+ *   npx tsx scripts/backfill-winner-team.ts --remote
+ *
+ * Zapis dopiero po dorzuceniu `--apply`:
+ *   npx tsx scripts/backfill-winner-team.ts --remote --apply
+ *
+ * Idempotentny — ponowne uruchomienie po aplikacji zgłosi 0 UPDATE-ów.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { determineTeam } from '../src/app/dramaafera/_utils/gameUtils';
+import { Teams } from '../src/constants/teams';
+
+const DATABASE_NAME = 'townofus-pl';
+const OUTPUT_FILE = 'db-backups/backfill-winner-team.sql';
+
+type WinnerRow = {
+    gameIdentifier: string;
+    winnerTeam: string | null;
+    winCondition: string | null;
+    playerName: string;
+    finalRole: string;
+};
+
+// Zwycięzcy każdej gry wraz z ich rolą KOŃCOWĄ (najwyższy `order` w player_roles).
+const QUERY = `
+SELECT g.gameIdentifier, g.winnerTeam, g.winCondition, p.name AS playerName,
+       (SELECT roleName FROM player_roles
+         WHERE gamePlayerStatisticsId = s.id
+         ORDER BY "order" DESC LIMIT 1) AS finalRole
+FROM game_player_statistics s
+JOIN games g ON g.id = s.gameId
+JOIN players p ON p.id = s.playerId
+WHERE g.deletedAt IS NULL AND s.win = 1
+`.replace(/\s+/g, ' ').trim();
+
+type Target = { flags: string[]; label: string };
+
+const TARGETS: Record<string, Target> = {
+    local: { flags: ['--local'], label: 'local' },
+    preview: { flags: ['--remote', '--preview'], label: 'preview' },
+    remote: { flags: ['--remote'], label: 'produkcja' },
+};
+
+function runWrangler(target: Target, extra: string[]): string {
+    const result = spawnSync('npx', ['wrangler', 'd1', 'execute', DATABASE_NAME, ...target.flags, ...extra], {
+        encoding: 'utf8',
+        maxBuffer: 50 * 1024 * 1024,
+    });
+
+    if (result.status !== 0) {
+        process.stderr.write(result.stderr ?? '');
+        throw new Error(`wrangler d1 execute zakończył się kodem ${result.status}`);
+    }
+
+    return result.stdout;
+}
+
+function fetchWinners(target: Target): WinnerRow[] {
+    const stdout = runWrangler(target, ['--json', '--command', QUERY]);
+    // wrangler potrafi dopisać ostrzeżenia przed JSON-em — bierzemy od pierwszego `[`.
+    return JSON.parse(stdout.slice(stdout.indexOf('[')))[0].results as WinnerRow[];
+}
+
+/**
+ * Priorytet Impostor > Crewmate > Neutral — ta sama kolejność co
+ * `calculateWinnerFromStats`, dzięki czemu API i UI dają ten sam wynik.
+ */
+function resolveWinner(winners: WinnerRow[]): { team: string; condition: string } {
+    const teams = winners.map((w) => determineTeam(w.finalRole));
+
+    const team = teams.includes(Teams.Impostor)
+        ? Teams.Impostor
+        : teams.includes(Teams.Crewmate)
+            ? Teams.Crewmate
+            : Teams.Neutral;
+
+    // Przy jednym zwycięzcy podajemy jego rolę — tak jak robi to `createGame.ts`.
+    const condition = winners.length === 1 ? `${winners[0].finalRole} victory` : `${team} victory`;
+
+    return { team, condition };
+}
+
+const quote = (value: string) => `'${value.replace(/'/g, "''")}'`;
+
+async function main(): Promise<void> {
+    const key = Object.keys(TARGETS).find((name) => process.argv.includes(`--${name}`));
+    if (!key) {
+        throw new Error('Podaj środowisko: --local, --preview albo --remote (opcjonalnie --apply).');
+    }
+    const target = TARGETS[key];
+    const apply = process.argv.includes('--apply');
+
+    console.log(`Czytam zwycięzców z bazy (${target.label})...`);
+    const rows = fetchWinners(target);
+
+    const byGame = new Map<string, WinnerRow[]>();
+    for (const row of rows) {
+        const list = byGame.get(row.gameIdentifier);
+        if (list) list.push(row);
+        else byGame.set(row.gameIdentifier, [row]);
+    }
+
+    const updates: string[] = [];
+    for (const [gameIdentifier, winners] of byGame) {
+        const { team, condition } = resolveWinner(winners);
+        if (winners[0].winnerTeam === team && winners[0].winCondition === condition) continue;
+
+        updates.push(
+            `UPDATE games SET winnerTeam = ${quote(team)}, winCondition = ${quote(condition)}` +
+            ` WHERE gameIdentifier = ${quote(gameIdentifier)};`,
+        );
+    }
+
+    console.log(`Gier ze zwycięzcą: ${byGame.size}. Do poprawy: ${updates.length}.`);
+
+    if (updates.length === 0) {
+        console.log('Nic do zrobienia — dane są już spójne.');
+        return;
+    }
+
+    await mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
+    await writeFile(OUTPUT_FILE, ['BEGIN TRANSACTION;', ...updates, 'COMMIT;', ''].join('\n'), 'utf8');
+    console.log(`Zapisano ${OUTPUT_FILE}.`);
+
+    if (!apply) {
+        console.log(`\nTo był podgląd — nic nie zapisano do bazy. Aby zastosować:`);
+        console.log(`  npx tsx scripts/backfill-winner-team.ts --${key} --apply`);
+        return;
+    }
+
+    console.log(`\nStosuję ${updates.length} UPDATE-ów na: ${target.label}...`);
+    runWrangler(target, ['--file', OUTPUT_FILE]);
+    console.log('Gotowe.');
+}
+
+main().catch((error) => {
+    console.error(error instanceof Error ? error.message : error);
+    process.exitCode = 1;
+});

--- a/src/app/api/games/_utils/createGame.ts
+++ b/src/app/api/games/_utils/createGame.ts
@@ -3,6 +3,8 @@ import { withoutDeleted } from '../../schema/common';
 import type { GameData } from '../../schema/games';
 import { calculateRankingForGame } from '../../_utils/rankingCalculator';
 import { getSeasonForDate } from '@/app/dramaafera/_constants/seasons';
+import { determineTeam } from '@/app/dramaafera/_utils/gameUtils';
+import { Teams } from '@/constants/teams';
 
 export interface CreateGameResult {
   gameId: number;
@@ -51,23 +53,23 @@ export async function createGameFromData(
   let winCondition: string | null = null;
 
   if (winners.length > 0) {
-    // For simplicity, determine team based on common roles
-    // This is a basic implementation - you might want to enhance this logic
-    const winnerRoles = winners.map(w => w.roleHistory[0]?.toLowerCase() || '');
-    
-    const impostorRoles = ['impostor', 'shapeshifter', 'morphling', 'swooper', 'glitch', 'venerer'];
-    const neutralRoles = ['jester', 'executioner', 'arsonist', 'plaguebearer', 'doomsayer', 'amnesiac'];
-    
-    if (winnerRoles.some(role => impostorRoles.includes(role))) {
-      winnerTeam = 'Impostor';
-    } else if (winnerRoles.some(role => neutralRoles.includes(role))) {
-      winnerTeam = 'Neutral';
+    // `determineTeam` resolves against the `Roles` registry and takes the FINAL
+    // role from roleHistory — a Traitor/Amnesiac wins with the team they ended
+    // on, not the one they started in. Priority Impostor > Crewmate > Neutral
+    // mirrors `calculateWinnerFromStats`, so the API and the UI agree.
+    const winnerTeams = winners.map(w => determineTeam(w.roleHistory));
+
+    if (winnerTeams.includes(Teams.Impostor)) {
+      winnerTeam = Teams.Impostor;
+    } else if (winnerTeams.includes(Teams.Crewmate)) {
+      winnerTeam = Teams.Crewmate;
     } else {
-      winnerTeam = 'Crewmate';
+      winnerTeam = Teams.Neutral;
     }
-    
+
     if (winners.length === 1) {
-      winCondition = `${winners[0].roleHistory[0]} victory`;
+      const roleHistory = winners[0].roleHistory;
+      winCondition = `${roleHistory[roleHistory.length - 1]} victory`;
     } else {
       winCondition = `${winnerTeam} victory`;
     }


### PR DESCRIPTION
## Problem

`createGame.ts` wyznaczał zwycięską drużynę z dwóch zaszytych na sztywno list ról:

```ts
impostorRoles = ['impostor','shapeshifter','morphling','swooper','glitch','venerer']
neutralRoles  = ['jester','executioner','arsonist','plaguebearer','doomsayer','amnesiac']
// wszystko inne -> 'Crewmate'
```

Cztery osobne błędy:

- **`glitch` jest rolą NEUTRALNĄ**, a stał na liście impostorów
- **brakowało 12 z 15 ról impostorskich** (Warlock, Blackmailer, Bomber, Escapist, Eclipsal, Grenadier, Hypnotist, Janitor, Miner, Scavenger, Traitor, Undertaker) → ich wygrane lądowały jako `Crewmate`
- **brakowało 5 neutralnych zabójców** (Werewolf, Juggernaut, Vampire, SoulCollector, Pestilence) → również jako `Crewmate`
- **`roleHistory[0]`** zamiast roli końcowej — Traitor/Amnesiac liczeni po roli, którą już nie grali

**190 z 642 gier (30%) miało błędną etykietę drużyny.**

Weryfikacja na losowej mislabelowanej grze `20251022_1921`, którą baza opisywała jako „Crewmate victory":

```
19:29:03  brubel (Vampire) killed Jakubeq (Mystic)
19:29:04  Cleopatrie (Vampire) killed Tajson (Morphling)
19:30:12  brubel (Vampire) guessed smoqu (Seer) — Correct guess
19:31:08  brubel (Vampire) killed DawDu (Undertaker)     <- ostatni impostor
```

Dwóch Vampirów wybija całe lobby. To wygrana neutralna.

## Skala pomyłki

| | wg bazy | faktycznie |
|---|---|---|
| Crewmate | 427 (66%) | **266 (41%)** |
| Impostor | 102 (16%) | **145 (23%)** |
| Neutral | 113 (18%) | **231 (36%)** |

Gra nie była „crew-sided", tylko **neutral-sided** — czyli odwrotnie, niż sugerowały statystyki.

## Rozwiązanie

Zamiast poprawiać listy — istniejący helper **`determineTeam()`** z `gameUtils.ts`. Rozwiązuje rolę przez rejestr `Roles`, więc zna wszystkie 55 ról i nie wymaga aktualizacji przy dodaniu nowej. Bierze rolę **końcową**. Priorytet `Impostor > Crewmate > Neutral` jest ten sam co w `calculateWinnerFromStats`, więc API i UI wreszcie dają zgodny wynik.

Ironia: `determineTeam()` miał te same błędne listy jako *fallback* — `createGame.ts` po prostu go nie wołał.

## Korekta historycznych danych

`scripts/backfill-winner-team.ts` — uruchamiany ręcznie, osobno dla każdego środowiska:

```bash
npx tsx scripts/backfill-winner-team.ts --local     # podgląd
npx tsx scripts/backfill-winner-team.ts --local --apply
npx tsx scripts/backfill-winner-team.ts --preview --apply
npx tsx scripts/backfill-winner-team.ts --remote --apply
```

Domyślnie tylko generuje SQL do przejrzenia; zapisuje dopiero z `--apply`. Idempotentny.

**Dlaczego skrypt, a nie migracja:** 226 UPDATE-ów w łańcuchu migracji odpalałoby się na każdej świeżej bazie już zawsze — także na dev i preview, gdzie dane są inne. Skrypt przelicza wartości na bieżąco tym samym `determineTeam()`, więc nie ma drugiego źródła prawdy o mapowaniu rola→drużyna. (Zduplikowanie tego mapowania w SQL odtworzyłoby dokładnie ten błąd, który naprawiamy.)

Na produkcji do poprawy: **226 wierszy**.

## Zasięg — co było popsute, co nie

| | stan |
|---|---|
| **Ranking / ELO** | ✅ nietknięty — `rankingCalculator.ts` liczy wyłącznie z `totalPoints`, nigdy nie czytał `winnerTeam` |
| **Lista gier na stronie** | ✅ OK — `getGamesList.ts` woła poprawny `calculateWinnerFromStats()` |
| Warunek zwycięstwa na stronie gry | ❌ `getGameData.ts:152` woli zapisaną wartość (`game.winCondition \|\| ...`) |
| `/api/games/stats` | ❌ agregaty crew/imp/neutral wprost z `winnerTeam` |
| `/api/games` + filtr `?winnerTeam=` | ❌ |
| `/api/games/[id]`, `/api/players/[id]` | ❌ |

## Jak testowane

- **Wszystkie 55 nazw ról** z bazy przepuszczone przez logikę dopasowania `determineTeam` — każda trafia w rejestr, fallback nie jest używany ani razu
- Produkcja zaimportowana lokalnie (`npm run db:import:local`), backfill zastosowany → agregaty 266/145/231
- Punkty kontrolne: `Blackmailer,Undertaker,Janitor` → Impostor; `Vampire,Vampire` → Neutral; 9 ról crew → Crewmate; `SoulCollector` solo → Neutral
- Idempotencja: celowe zepsucie 2 wierszy → skrypt wykrywa 2, naprawia, ponowne uruchomienie zgłasza 0
- `tsc --noEmit` czysty (dwa błędy o `generated/zod` są wcześniejsze — brak wygenerowanych schematów)

## Uwaga dla recenzenta

Przy jednym zwycięzcy `winCondition` pokazuje teraz rolę **końcową** zamiast startowej — Amnesiac, który został Vampirem i wygrał solo, to `Vampire victory`, a nie `Amnesiac victory`. To widoczna zmiana na stronie pojedynczej gry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
