### PR TITLE
fix: usuń BEGIN TRANSACTION z SQL generowanego przez backfill

### DIFF
--- a/scripts/backfill-winner-team.ts
+++ b/scripts/backfill-winner-team.ts
@@ -133,8 +133,14 @@ async function main(): Promise<void> {
         return;
     }
 
+    // Bez BEGIN TRANSACTION / COMMIT — zdalne D1 odrzuca je z błędem
+    // "please use the state.storage.transaction() ... APIs instead", nawet jeśli
+    // miniflare lokalnie je przepuszcza. Skutek: przerwanie w połowie zostawia
+    // częściowo naniesioną korektę. Nie szkodzi — każdy UPDATE adresuje wiersz
+    // po gameIdentifier, a skrypt jest idempotentny, więc wystarczy uruchomić
+    // go ponownie, żeby dokończyć resztę.
     await mkdir(path.dirname(OUTPUT_FILE), { recursive: true });
-    await writeFile(OUTPUT_FILE, ['BEGIN TRANSACTION;', ...updates, 'COMMIT;', ''].join('\n'), 'utf8');
+    await writeFile(OUTPUT_FILE, [...updates, ''].join('\n'), 'utf8');
     console.log(`Zapisano ${OUTPUT_FILE}.`);
 
     if (!apply) {


### PR DESCRIPTION
Follow-up do #279.

## Problem

`scripts/backfill-winner-team.ts --remote --apply` wywalał się przed wykonaniem czegokolwiek:

```
✘ [ERROR] To execute a transaction, please use the state.storage.transaction()
  or state.storage.transactionSync() APIs instead of the SQL BEGIN TRANSACTION
  or SAVEPOINT statements.
```

Zdalne D1 nie przyjmuje `BEGIN TRANSACTION` / `COMMIT` w plikach podawanych przez `wrangler d1 execute --file`. Miniflare lokalnie je przepuszcza, więc `--local --apply` przechodził bez problemu — i tylko tak to przetestowałem w #279.

`.github/skills/import-d1-database/SKILL.md` wymienia „wrangler transaction restrictions" jako jeden ze znanych trybów awarii przy pracy z D1; ten sam problem, inny plik.

## Zmiana

Generowany SQL to teraz same `UPDATE`-y, bez opakowania w transakcję.

## Konsekwencja

Przerwanie w połowie zostawia częściowo naniesioną korektę. Jest to bezpieczne:

- każdy `UPDATE` adresuje wiersz po `gameIdentifier`, nie po pozycji czy stanie
- skrypt przelicza wartości na bieżąco z aktualnego stanu bazy, więc jest idempotentny
- ponowne uruchomienie po prostu dokończy resztę

Powód jest zapisany w komentarzu przy zapisie pliku, żeby transakcja nie wróciła przy następnym czytaniu tego kodu.

## Jak testowane

- `--local --apply` na 2 celowo zepsutych wierszach → naprawia, ponowne uruchomienie zgłasza 0
- wygenerowany plik zaczyna się od pierwszego `UPDATE`, bez `BEGIN`
- `tsc --noEmit` czysty
- **Produkcja nietknięta** — nieudany przebieg z #279 niczego nie zapisał (agregaty nadal 427/102/113), więc backfill wciąż czeka na uruchomienie

🤖 Generated with [Claude Code](https://claude.com/claude-code)
